### PR TITLE
fix worldmap after change to maxmind local db

### DIFF
--- a/tautulli.py
+++ b/tautulli.py
@@ -60,7 +60,7 @@ for session in sessions.keys():
             "measurement": "Tautulli",
             "tags": {
                 "type": "Session",
-                "region_code": geodata.city.geoname_id,
+                "region_code": geodata.subdivisions.most_specific.iso_code,
                 "name": sessions[session]['friendly_name']
             },
             "time": current_time,


### PR DESCRIPTION
https://geoip2.readthedocs.io/en/latest/    
2 letter state = subdivisions.most_specific.iso_code dashboard is currently using state to propagate the map, using the city.geoname_id was causing map to not update due to the geo ID being used
Fixes #10 